### PR TITLE
infra: containerização do backend java para testar a viabilidade de  deploy OCI

### DIFF
--- a/api-backend/Dockerfile
+++ b/api-backend/Dockerfile
@@ -1,0 +1,49 @@
+# ===================================================================
+# STAGE 1: Build (compila o JAR)
+# ===================================================================
+FROM eclipse-temurin:21-jdk-alpine AS builder
+
+WORKDIR /app
+
+COPY .mvn .mvn
+COPY mvnw pom.xml ./
+
+# Torna o mvnw executável (garante permissão Linux)
+RUN chmod +x mvnw
+
+# Baixa dependências (Cache Layer)
+RUN ./mvnw dependency:go-offline -B
+
+# Copia o código fonte
+COPY src ./src
+
+# Build do JAR
+RUN ./mvnw clean package -DskipTests
+
+# ===================================================================
+# STAGE 2: Runtime (executa a aplicação)
+# ===================================================================
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+# Cria usuário não-root
+RUN addgroup -S spring && adduser -S spring -G spring
+
+# Copia o JAR do builder
+COPY --from=builder /app/target/*.jar app.jar
+
+# Define o usuário
+USER spring:spring
+
+EXPOSE 8080
+
+# Entrypoint otimizado
+ENTRYPOINT ["java", \
+    "-XX:+UseContainerSupport", \
+    "-XX:MaxRAMPercentage=75.0", \
+    "-XX:InitialRAMPercentage=50.0", \
+    "-XX:+UseG1GC", \
+    "-Djava.security.egd=file:/dev/./urandom", \
+    "-jar", \
+    "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
 services:
-  # --- Serviço Python (Machine Learning) ---
-  # Esse JÁ VAI FUNCIONAR AGORA.
+  # ========================================
+  # Serviço Python (Machine Learning)
+  # =======================================
   ml-api:
     build:
       context: ./ml/model_api
       dockerfile: Dockerfile
     container_name: ml_api_container
+    # Depois mudar para "expose" "8000" para não expor o microserviço python fora do container
     ports:
       - "8000:8000"
     environment:
@@ -14,29 +16,38 @@ services:
     networks:
       - app-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').getcode() == 200 else 1)"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 5s # Dá um tempinho extra para o boot frio do Python
 
-  # --- Serviço Java (Backend Spring) ---
-  # PREVISTO: Se der tempo de criar o Dockerfile no Java,
-  # ---------------------------------------------
-  # api-backend:
-  #   build:
-  #     context: ./api-backend
-  #     dockerfile: Dockerfile
-  #   container_name: backend_java_container
-  #   ports:
-  #     - "8080:8080"
-  #   environment:
-  #     - ML_API_URL=http://ml-api:8000
-  #   depends_on:
-  #     ml-api:
-  #       condition: service_healthy
-  #   networks:
-  #     - app-network
+  # ========================================
+  # Serviço Java (Backend Spring)
+  # ========================================
+  api-backend:
+    build:
+      context: ./api-backend
+      dockerfile: Dockerfile
+    container_name: backend_java_container
+    ports:
+      - "8080:8080"  # Expõe publicamente
+    environment: # Pode mudar para .env
+      - API_BASE_URL=http://ml-api:8000
+      - SPRING_PROFILES_ACTIVE=prod
+    depends_on: 
+      ml-api:
+        condition: service_healthy
+    networks:
+      - app-network
+
+    deploy:
+      resources: 
+        limits:
+          cpus:  '0.5'
+          memory: 500M
+        reservations:
+          memory: 300M
 
 # Rede interna
 networks:


### PR DESCRIPTION
## Descrição
Este PR propõe uma sugestão infraestrutura base para containerização da API Java e ajustes na orquestração dos microsserviços.

**Objetivo & Contexto:**
O foco principal destas alterações é viabilizar o **teste de deploy na infraestrutura da OCI (Oracle Cloud)**.

**Nota ao time de Backend:**
Peço licença pela "intromissão" na estrutura do projeto Java (`api-backend/`). Fiquem 100% à vontade para revisar, sugerir alterações ou até rejeitar este PR se algo não estiver alinhado com o padrão que vocês estão definindo.

**Estratégia de Validação (Por que Fork?):**
Como sou colaborador e não tenho acesso às configurações de *Secrets* deste repositório (necessárias para o CI/CD), adotarei o seguinte fluxo:
1.  Vou utilizar um **Fork** pessoal para validar o pipeline de construção das imagens (GHCR) e o deploy real na VM da OCI.
2.  Assim que o processo estiver validado e funcionando na nuvem, trarei as configurações de pipeline (`.github/workflows`) de volta para este PR (ou um novo) para integrarmos ao repositório oficial.

**Principais alterações:**
- **Backend (Java):**
  - Criação de `Dockerfile` Multi-stage (reduz imagem final e isola build tools).
  - Configuração de usuário não-root (`spring`) por segurança.
  - Ajuste dinâmico de memória JVM (`MaxRAMPercentage`) para evitar OOM no container.
- **Infra (Docker Compose):**
  - **Segurança:** A API Python (`ml-api`) pode deixar de ser exposta 
  - **Resiliência:** O container Java agora aguarda explicitamente o `healthcheck` do Python antes de iniciar.
  - **Recursos:** Definição de limites de CPU e Memória para evitar travamento da máquina host.

## Como testar
1. Baixe a branch: `git checkout infra/feature-docker-backend-java`
2. Suba o ambiente: `docker compose up --build`
3. Verifique se os dois containers estão saudáveis: `docker compose ps`
4. Teste a rota principal (via Java):

```bash
curl -X POST http://localhost:8080/reter/prever \
-H "Content-Type: application/json" \
-d '{
  "genero": "homem",
  "idoso": 0,
  "parceiro": 1,
  "dependentes": 0,
  "tempo_contrato_meses": 12,
  "servico_telefone": 1,
  "linhas_multiplas": "nao",
  "tipo_internet": "fibra",
  "seguranca_online": "sim",
  "backup_online": "nao",
  "protecao_dispositivo": "nao",
  "suporte_tecnico": "nao",
  "streaming_tv": "sim",
  "streaming_filmes": "sim",
  "tipo_contrato": "mensal",
  "cobranca_digital": 1,
  "metodo_pagamento": "cheque_eletronico",
  "cobranca_mensal": 79.85,
  "cobranca_total": 1200.50
  }'